### PR TITLE
Adicionar suporte a exportação ONNX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up down test train shell notebook format lint clean help build-rocm train-rocm notebook-rocm up-rocm down-rocm
+.PHONY: build up down test train shell notebook format lint clean help build-rocm train-rocm notebook-rocm up-rocm down-rocm export-onnx export-onnx-rocm
 
 # Variáveis
 PROJECT_NAME = credential-pattern-detector
@@ -54,6 +54,16 @@ lint: ## Executa análise estática de código
 
 clean: ## Remove arquivos temporários e caches
 	docker-compose run --rm app bash -c "find . -type d -name __pycache__ -exec rm -rf {} +; find . -type f -name '*.pyc' -delete; find . -type d -name '.pytest_cache' -exec rm -rf {} +; find . -type d -name '.mypy_cache' -exec rm -rf {} +;"
+
+# Exportar modelo para ONNX
+export-onnx:
+	@echo "Exportando modelo para ONNX..."
+	docker-compose run --rm app python -m src.export.export_onnx --model models/credential_detector_model.pkl --output models/onnx
+
+# Exportar modelo para ONNX com GPU ROCm
+export-onnx-rocm:
+	@echo "Exportando modelo para ONNX com GPU ROCm..."
+	docker-compose -f docker-compose.rocm.yml run --rm app python -m src.export.export_onnx --model models/credential_detector_model.pkl --output models/onnx
 
 # Valor padrão se nenhum alvo for especificado
 .DEFAULT_GOAL := help 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Uma inteligência artificial projetada para identificar padrões de credenciais 
 - Baixa taxa de falsos positivos
 - Rápido o suficiente para uso em aplicações em tempo real
 - Fácil integração com diferentes linguagens e plataformas
+- **Novo**: Exportação para ONNX, permitindo uso em PHP, JavaScript e outras linguagens
 
 ## Estrutura do Projeto
 
@@ -24,11 +25,13 @@ credential-pattern-detector/
 │   ├── processed/             # Dados processados para treinamento
 │   └── test/                  # Conjunto de testes
 ├── models/                    # Modelos treinados
+│   └── onnx/                  # Modelos exportados para ONNX
 ├── notebooks/                 # Jupyter notebooks para experimentação
 ├── src/                       # Código fonte
 │   ├── detector/              # Módulo principal de detecção
 │   ├── training/              # Scripts de treinamento
 │   ├── evaluation/            # Scripts de avaliação
+│   ├── export/                # Scripts para exportação de modelos
 │   └── utils/                 # Utilitários
 ├── tests/                     # Testes unitários e de integração
 ├── examples/                  # Exemplos de uso
@@ -143,6 +146,36 @@ docker-compose run --rm app python -m src.evaluation.evaluate --model models/cre
 # Localmente
 python -m src.evaluation.evaluate --model models/credential_detector_model.pkl
 ```
+
+## Exportação para Outras Linguagens (ONNX)
+
+O detector pode ser exportado para o formato ONNX (Open Neural Network Exchange), permitindo seu uso em outras linguagens como PHP, JavaScript, C#, Java, etc.
+
+### Exportando o modelo para ONNX
+
+```bash
+# Com Docker
+docker-compose run --rm app python -m src.export.export_onnx --model models/credential_detector_model.pkl --output models/onnx
+
+# Localmente
+python -m src.export.export_onnx --model models/credential_detector_model.pkl --output models/onnx
+```
+
+Após a exportação, serão gerados os seguintes arquivos:
+- `credential_detector.onnx`: Modelo em formato ONNX
+- `credential_detector_vectorizer.json`: Dados do vectorizer para processamento de texto
+- `credential_detector_patterns.json`: Padrões de expressões regulares para detecção
+- `credential_detector_config.json`: Configurações do modelo
+- `credential_detector_php_example.php`: Exemplo de implementação em PHP
+- `credential_detector_js_example.js`: Exemplo de implementação em JavaScript
+
+### Usando o modelo em PHP
+
+Para utilizar o modelo em PHP, consulte o [Cliente PHP para Detector de Credenciais](https://github.com/rfschubert/php-credential-detector).
+
+### Usando o modelo em JavaScript
+
+Um exemplo básico de uso do modelo em JavaScript está disponível no arquivo gerado na exportação.
 
 ## Explorando com Jupyter Notebook
 

--- a/examples/use_onnx_detector.py
+++ b/examples/use_onnx_detector.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Exemplo de uso do detector ONNX para detecção de credenciais.
+Este script demonstra como carregar e usar um modelo ONNX exportado.
+"""
+
+import os
+import sys
+import json
+import argparse
+from typing import List, Dict, Any
+
+# Adicionar diretório raiz ao path para importação
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:
+    from src.utils.onnx_loader import load_detector, ONNXCredentialDetector
+except ImportError as e:
+    print(f"Erro ao importar o detector ONNX: {e}")
+    print("Certifique-se de que o pacote onnxruntime está instalado:")
+    print("pip install onnxruntime")
+    sys.exit(1)
+
+def detect_credentials(
+    text: str, 
+    detector: ONNXCredentialDetector
+) -> Dict[str, Any]:
+    """
+    Detecta credenciais em um texto usando o detector ONNX.
+    
+    Args:
+        text: Texto a ser analisado
+        detector: Detector ONNX carregado
+        
+    Returns:
+        Resultado da detecção
+    """
+    result = detector.detect(text)
+    return result
+
+def format_result(result: Dict[str, Any], text: str) -> str:
+    """
+    Formata o resultado da detecção para exibição.
+    
+    Args:
+        result: Resultado da detecção
+        text: Texto original
+        
+    Returns:
+        Texto formatado
+    """
+    has_credential = result.get("has_credential", False)
+    confidence = result.get("confidence", 0.0)
+    matches = result.get("matches", [])
+    positions = result.get("match_positions", [])
+    
+    formatted = f"Texto analisado: {text}\n"
+    formatted += f"Contém credencial: {'Sim' if has_credential else 'Não'}\n"
+    formatted += f"Confiança: {confidence:.4f}\n"
+    
+    if matches:
+        formatted += "Credenciais encontradas:\n"
+        for idx, match in enumerate(matches):
+            formatted += f"  {idx+1}. {match}\n"
+    
+    if positions:
+        formatted += "Posições encontradas:\n"
+        for start, end, match_type in positions:
+            formatted += f"  - Posição {start}-{end} (Tipo: {match_type}): {text[start:end]}\n"
+    
+    return formatted
+
+def main():
+    """
+    Função principal do exemplo.
+    """
+    parser = argparse.ArgumentParser(description="Detector de credenciais usando modelo ONNX")
+    parser.add_argument(
+        "--model-dir", 
+        default="models/onnx",
+        help="Diretório contendo o modelo ONNX"
+    )
+    parser.add_argument(
+        "--model-name", 
+        default="credential_detector",
+        help="Nome base do modelo ONNX"
+    )
+    parser.add_argument(
+        "--text", 
+        default=None,
+        help="Texto a ser analisado (se não fornecido, exemplos predefinidos serão usados)"
+    )
+    parser.add_argument(
+        "--json", 
+        action="store_true",
+        help="Retornar resultado em formato JSON"
+    )
+    
+    args = parser.parse_args()
+    
+    # Exemplos para teste
+    examples = [
+        "Olá, como vai você? Tudo bem?",
+        "Minha senha é X#9pL@7!2ZqR e meu usuário é joao123",
+        "API_KEY=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+        "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
+        "AKIA6QOKC2QOKC2EXAMPLE",
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAxzYk86/s0Q==\n-----END RSA PRIVATE KEY-----"
+    ]
+    
+    try:
+        # Carregar o detector
+        detector = load_detector(
+            model_directory=args.model_dir,
+            model_name=args.model_name
+        )
+        
+        # Processar texto fornecido ou exemplos
+        if args.text:
+            texts = [args.text]
+        else:
+            texts = examples
+        
+        results = []
+        
+        for text in texts:
+            result = detect_credentials(text, detector)
+            results.append(result)
+            
+            if not args.json:
+                print("\n" + "="*50)
+                print(format_result(result, text))
+        
+        if args.json:
+            # Adicionar o texto original ao resultado
+            for i, result in enumerate(results):
+                result["text"] = texts[i]
+            
+            # Imprimir JSON
+            print(json.dumps(results, indent=2))
+            
+    except Exception as e:
+        print(f"Erro ao executar o detector: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+    
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,12 @@ joblib>=1.1.0
 tqdm>=4.62.0
 pyyaml>=6.0
 
+# Suporte a ONNX
+onnx>=1.14.0
+onnxruntime>=1.15.0
+skl2onnx>=1.14.0
+tf2onnx>=1.14.0  # Para converter modelos TensorFlow se necessário
+
 # Para desenvolvimento e testes
 pytest>=7.0.0
 black>=22.1.0

--- a/src/export/__init__.py
+++ b/src/export/__init__.py
@@ -1,0 +1,7 @@
+"""
+Módulo de exportação para formatos compatíveis com outras linguagens.
+"""
+
+from .export_onnx import export_model
+
+__all__ = ['export_model'] 

--- a/src/export/export_onnx.py
+++ b/src/export/export_onnx.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Script para exportar o modelo de detecção de credenciais para o formato ONNX.
+ONNX permite que o modelo seja carregado em diferentes ambientes como PHP e JavaScript.
+"""
+
+import os
+import sys
+import argparse
+import logging
+from typing import Dict, List, Optional, Any, Tuple
+
+import numpy as np
+import json
+
+# Adicionar diretório raiz ao path para importação
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.utils.onnx_utils import convert_credential_detector_to_onnx
+from src.detector.credential_detector import CredentialDetector
+
+# Configurar logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+def export_model(
+    model_path: str,
+    output_dir: str,
+    model_name: str = "credential_detector",
+    test_examples: Optional[List[str]] = None
+) -> Dict[str, str]:
+    """
+    Exporta o modelo para ONNX e gera arquivos auxiliares para uso em outras linguagens.
+    
+    Args:
+        model_path: Caminho para o arquivo .pkl do modelo treinado
+        output_dir: Diretório onde os arquivos convertidos serão salvos
+        model_name: Nome base para os arquivos gerados
+        test_examples: Lista de exemplos para testar o modelo após exportação
+        
+    Returns:
+        Dicionário com os caminhos para os arquivos gerados
+    """
+    logger.info(f"Exportando modelo de {model_path} para ONNX")
+    
+    # Carregar o detector para extrair os padrões regex também
+    detector = CredentialDetector(model_path=model_path)
+    
+    # Converter o modelo para ONNX
+    export_paths = convert_credential_detector_to_onnx(
+        model_path=model_path,
+        output_dir=output_dir,
+        model_name=model_name
+    )
+    
+    # Exportar os padrões regex para uso em outras linguagens
+    patterns_path = os.path.join(output_dir, f"{model_name}_patterns.json")
+    
+    # Convertendo os padrões regex para strings serialáveis
+    serializable_patterns = {}
+    for pattern_type, pattern in detector.patterns.items():
+        if hasattr(pattern, "pattern"):
+            serializable_patterns[pattern_type] = {
+                "pattern": pattern.pattern,
+                "flags": pattern.flags
+            }
+        else:
+            serializable_patterns[pattern_type] = str(pattern)
+    
+    with open(patterns_path, "w", encoding="utf-8") as f:
+        json.dump(serializable_patterns, f, ensure_ascii=False, indent=2)
+    
+    export_paths["patterns"] = patterns_path
+    
+    # Gerar exemplos de implementação para PHP e JavaScript
+    generate_implementation_examples(output_dir, model_name)
+    
+    # Testar com exemplos, se fornecidos
+    if test_examples:
+        test_results = []
+        for example in test_examples:
+            result = detector.detect(example)
+            test_results.append({
+                "text": example,
+                "has_credential": result.has_credential,
+                "confidence": float(result.confidence),
+                "matches": result.matches,
+                "match_positions": [
+                    {"start": start, "end": end, "type": match_type}
+                    for start, end, match_type in (result.match_positions or [])
+                ]
+            })
+            
+        # Salvar resultados de teste para verificação
+        test_results_path = os.path.join(output_dir, f"{model_name}_test_results.json")
+        with open(test_results_path, "w", encoding="utf-8") as f:
+            json.dump(test_results, f, ensure_ascii=False, indent=2)
+            
+        export_paths["test_results"] = test_results_path
+        
+    logger.info(f"Exportação concluída. Arquivos gerados em {output_dir}")
+    
+    # Listar todos os arquivos gerados
+    for name, path in export_paths.items():
+        logger.info(f"- {name}: {path}")
+    
+    return export_paths
+
+def generate_implementation_examples(output_dir: str, model_name: str) -> None:
+    """
+    Gera exemplos de código para implementação em PHP e JavaScript.
+    
+    Args:
+        output_dir: Diretório onde os exemplos serão salvos
+        model_name: Nome base do modelo
+    """
+    # Exemplo de implementação em PHP
+    php_example = """<?php
+/**
+ * Exemplo de implementação do detector de credenciais em PHP.
+ * Requer a extensão PHP ORT (ONNX Runtime)
+ * https://github.com/microsoft/onnxruntime-php
+ */
+
+namespace RfSchubert\\CredentialDetector;
+
+class Detector {
+    private $onnxModel;
+    private $vectorizer;
+    private $patterns;
+    private $config;
+    private $confidenceThreshold;
+
+    public function __construct(string $modelPath, string $vectorizerPath, string $patternsPath, string $configPath) {
+        // Carregar o modelo ONNX
+        $this->onnxModel = new \\ORT\\Session($modelPath);
+        
+        // Carregar o vectorizer
+        $this->vectorizer = json_decode(file_get_contents($vectorizerPath), true);
+        
+        // Carregar os padrões regex
+        $this->patterns = json_decode(file_get_contents($patternsPath), true);
+        
+        // Carregar a configuração
+        $this->config = json_decode(file_get_contents($configPath), true);
+        
+        // Definir o limite de confiança
+        $this->confidenceThreshold = $this->config['confidence_threshold'] ?? 0.7;
+    }
+    
+    /**
+     * Detecta credenciais em uma string de texto.
+     */
+    public function detect(string $text): DetectionResult {
+        // Detectar usando regex primeiro
+        $regexMatches = $this->detectWithRegex($text);
+        
+        // Se encontrou correspondências por regex, retornar diretamente
+        if (!empty($regexMatches['matches'])) {
+            return new DetectionResult(
+                true,
+                1.0,
+                $regexMatches['matches'],
+                $regexMatches['positions']
+            );
+        }
+        
+        // Extrair features
+        $features = $this->extractFeatures($text);
+        
+        // Vectorizar o texto
+        $vector = $this->vectorizeText($features);
+        
+        // Fazer a previsão com o modelo ONNX
+        $input = ['input' => $vector];
+        $output = $this->onnxModel->run($input);
+        
+        // O output contém as probabilidades para cada classe [não_credencial, credencial]
+        $probabilities = $output[0][0];
+        $confidence = $probabilities[1]; // Probabilidade da classe "credencial"
+        
+        $hasCredential = $confidence >= $this->confidenceThreshold;
+        
+        return new DetectionResult(
+            $hasCredential,
+            $confidence,
+            $hasCredential ? [$text] : [],
+            []
+        );
+    }
+    
+    // Implementações dos métodos auxiliares
+    // ...
+}
+
+class DetectionResult {
+    public $hasCredential;
+    public $confidence;
+    public $matches;
+    public $matchPositions;
+    
+    public function __construct(bool $hasCredential, float $confidence, array $matches, array $matchPositions) {
+        $this->hasCredential = $hasCredential;
+        $this->confidence = $confidence;
+        $this->matches = $matches;
+        $this->matchPositions = $matchPositions;
+    }
+}
+"""
+
+    # Exemplo de implementação em JavaScript
+    js_example = """/**
+ * Exemplo de implementação do detector de credenciais em JavaScript.
+ * Requer a biblioteca ONNX.js
+ * https://github.com/microsoft/onnxjs
+ */
+
+class CredentialDetector {
+  constructor(modelPath, vectorizerData, patternsData, configData) {
+    this.session = null;
+    this.vectorizer = vectorizerData;
+    this.patterns = patternsData;
+    this.config = configData;
+    this.confidenceThreshold = configData.confidence_threshold || 0.7;
+    
+    // Carregar o modelo ONNX
+    this.loadModel(modelPath);
+  }
+  
+  async loadModel(modelPath) {
+    // Importar ONNX.js
+    const onnx = require('onnxjs');
+    
+    // Criar uma sessão
+    this.session = new onnx.InferenceSession();
+    
+    // Carregar o modelo
+    await this.session.loadModel(modelPath);
+    
+    console.log('Modelo ONNX carregado com sucesso!');
+  }
+  
+  async detect(text) {
+    // Verificar se o modelo foi carregado
+    if (!this.session) {
+      throw new Error('Modelo ONNX não carregado');
+    }
+    
+    // Detectar usando regex primeiro
+    const regexResult = this.detectWithRegex(text);
+    
+    if (regexResult.matches.length > 0) {
+      return {
+        hasCredential: true,
+        confidence: 1.0,
+        matches: regexResult.matches,
+        matchPositions: regexResult.positions
+      };
+    }
+    
+    // Extrair features
+    const features = this.extractFeatures(text);
+    
+    // Vectorizar o texto
+    const vector = this.vectorizeText(features);
+    
+    // Preparar o tensor de entrada
+    const inputTensor = new onnx.Tensor(new Float32Array(vector), 'float32', [1, vector.length]);
+    
+    // Fazer a inferência
+    const outputMap = await this.session.run([inputTensor]);
+    const outputTensor = outputMap.values().next().value;
+    
+    // Obter as probabilidades
+    const probabilities = outputTensor.data;
+    const confidence = probabilities[1]; // Classe 1 = credencial
+    
+    const hasCredential = confidence >= this.confidenceThreshold;
+    
+    return {
+      hasCredential,
+      confidence,
+      matches: hasCredential ? [text] : [],
+      matchPositions: []
+    };
+  }
+  
+  // Implementações dos métodos auxiliares
+  // ...
+}
+
+// Exemplo de uso
+async function example() {
+  // Carregar os dados
+  const fs = require('fs');
+  const path = require('path');
+  
+  const modelPath = path.join(__dirname, 'credential_detector.onnx');
+  const vectorizerData = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'credential_detector_vectorizer.json'), 'utf8'
+  ));
+  const patternsData = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'credential_detector_patterns.json'), 'utf8'
+  ));
+  const configData = JSON.parse(fs.readFileSync(
+    path.join(__dirname, 'credential_detector_config.json'), 'utf8'
+  ));
+  
+  // Inicializar o detector
+  const detector = new CredentialDetector(
+    modelPath, vectorizerData, patternsData, configData
+  );
+  
+  // Detectar credenciais
+  const text = 'API_KEY=a1b2c3d4e5f6g7h8i9j0';
+  const result = await detector.detect(text);
+  
+  console.log('Texto:', text);
+  console.log('Resultado:', result);
+}
+"""
+
+    # Salvar os exemplos
+    php_example_path = os.path.join(output_dir, f"{model_name}_php_example.php")
+    with open(php_example_path, "w", encoding="utf-8") as f:
+        f.write(php_example)
+    
+    js_example_path = os.path.join(output_dir, f"{model_name}_js_example.js")
+    with open(js_example_path, "w", encoding="utf-8") as f:
+        f.write(js_example)
+    
+    logger.info(f"Exemplos de implementação gerados em:")
+    logger.info(f"- PHP: {php_example_path}")
+    logger.info(f"- JavaScript: {js_example_path}")
+
+def main():
+    """
+    Função principal para execução do script.
+    """
+    parser = argparse.ArgumentParser(description="Exportar modelo para ONNX")
+    parser.add_argument(
+        "--model", 
+        default="models/credential_detector_model.pkl",
+        help="Caminho para o modelo treinado (.pkl)"
+    )
+    parser.add_argument(
+        "--output", 
+        default="models/onnx",
+        help="Diretório de saída para os arquivos exportados"
+    )
+    parser.add_argument(
+        "--name", 
+        default="credential_detector",
+        help="Nome base para os arquivos gerados"
+    )
+    
+    args = parser.parse_args()
+    
+    # Exemplos de teste
+    test_examples = [
+        "Olá, como vai você?",
+        "Minha senha é X#9pL@7!2ZqR e meu usuário é joao123",
+        "API_KEY=a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+        "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
+        "AKIA6QOKC2QOKC2EXAMPLE",
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAxzYk86/s0Q==\n-----END RSA PRIVATE KEY-----"
+    ]
+    
+    # Exportar o modelo
+    export_paths = export_model(
+        model_path=args.model,
+        output_dir=args.output,
+        model_name=args.name,
+        test_examples=test_examples
+    )
+    
+    logger.info("Exportação concluída com sucesso!")
+
+if __name__ == "__main__":
+    main() 

--- a/src/utils/onnx_loader.py
+++ b/src/utils/onnx_loader.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Utilitários para carregamento e uso de modelos ONNX.
+Este módulo facilita o uso de modelos ONNX em diferentes ambientes.
+"""
+
+import os
+import json
+import logging
+from typing import Dict, Any, List, Tuple, Optional, Union
+
+import numpy as np
+import regex as re
+try:
+    import onnxruntime as ort
+    ONNX_AVAILABLE = True
+except ImportError:
+    ONNX_AVAILABLE = False
+    logging.warning("ONNX Runtime não disponível. Instale com 'pip install onnxruntime'")
+
+logger = logging.getLogger(__name__)
+
+class ONNXCredentialDetector:
+    """
+    Detector de credenciais usando modelo ONNX.
+    Permite usar o modelo CredentialDetector exportado para ONNX.
+    """
+    
+    def __init__(
+        self, 
+        model_path: str, 
+        config_path: Optional[str] = None,
+        vectorizer_path: Optional[str] = None,
+        patterns_path: Optional[str] = None,
+        confidence_threshold: float = 0.7
+    ):
+        """
+        Inicializa o detector de credenciais com um modelo ONNX.
+        
+        Args:
+            model_path: Caminho para o modelo ONNX
+            config_path: Caminho para a configuração do modelo (opcional)
+            vectorizer_path: Caminho para os dados do vectorizer (opcional)
+            patterns_path: Caminho para os padrões regex (opcional)
+            confidence_threshold: Limiar de confiança para classificação
+        """
+        if not ONNX_AVAILABLE:
+            raise ImportError("ONNX Runtime não está disponível. Instale com 'pip install onnxruntime'")
+        
+        # Carregar o modelo ONNX
+        self.session = ort.InferenceSession(model_path)
+        
+        # Definir valores padrão
+        self.config = {}
+        self.vectorizer_data = {}
+        self.patterns = {}
+        self.confidence_threshold = confidence_threshold
+        
+        # Se o caminho da configuração não foi fornecido, tentar inferir
+        if config_path is None:
+            config_path = model_path.replace(".onnx", "_config.json")
+        
+        # Carregar configuração
+        if os.path.exists(config_path):
+            with open(config_path, "r", encoding="utf-8") as f:
+                self.config = json.load(f)
+                if "confidence_threshold" in self.config:
+                    self.confidence_threshold = self.config["confidence_threshold"]
+        
+        # Se o caminho do vectorizer não foi fornecido, tentar inferir
+        if vectorizer_path is None:
+            vectorizer_path = model_path.replace(".onnx", "_vectorizer.json")
+        
+        # Carregar dados do vectorizer
+        if os.path.exists(vectorizer_path):
+            with open(vectorizer_path, "r", encoding="utf-8") as f:
+                self.vectorizer_data = json.load(f)
+        
+        # Se o caminho dos padrões não foi fornecido, tentar inferir
+        if patterns_path is None:
+            patterns_path = model_path.replace(".onnx", "_patterns.json")
+        
+        # Carregar padrões
+        if os.path.exists(patterns_path):
+            with open(patterns_path, "r", encoding="utf-8") as f:
+                patterns_data = json.load(f)
+                
+                # Compilar padrões regex
+                self.patterns = {}
+                for pattern_name, pattern_info in patterns_data.items():
+                    if isinstance(pattern_info, dict) and "pattern" in pattern_info:
+                        flags = pattern_info.get("flags", 0)
+                        self.patterns[pattern_name] = re.compile(pattern_info["pattern"], flags)
+                    elif isinstance(pattern_info, str):
+                        self.patterns[pattern_name] = re.compile(pattern_info)
+    
+    def vectorize_text(self, text: str) -> np.ndarray:
+        """
+        Vetoriza o texto usando o vocabulário do TF-IDF.
+        
+        Args:
+            text: Texto a ser vetorizado
+            
+        Returns:
+            Array NumPy com o vetor TF-IDF
+        """
+        if not self.vectorizer_data or "vocabulary" not in self.vectorizer_data:
+            raise ValueError("Dados do vectorizer não foram carregados corretamente")
+        
+        vocabulary = self.vectorizer_data["vocabulary"]
+        
+        # Criar vetor esparso
+        vector = np.zeros(len(vocabulary))
+        
+        # Implementação simplificada de vetorização TF-IDF
+        # (Uma implementação completa replicaria exatamente o comportamento do TfidfVectorizer)
+        ngram_min, ngram_max = self.vectorizer_data.get("ngram_range", (1, 1))
+        
+        # Considerar analyzer char_wb (word-boundary) por padrão
+        text_tokens = []
+        for n in range(ngram_min, ngram_max + 1):
+            for i in range(len(text) - n + 1):
+                ngram = text[i:i+n]
+                text_tokens.append(ngram)
+        
+        # Contar frequência dos tokens
+        for token in text_tokens:
+            if token in vocabulary:
+                idx = vocabulary[token]
+                vector[idx] += 1
+        
+        # Normalizar (simplificado)
+        if np.sum(vector) > 0:
+            vector = vector / np.sqrt(np.sum(vector**2))
+        
+        # Aplicar IDF (se disponível)
+        if "idf" in self.vectorizer_data and self.vectorizer_data["idf"]:
+            idf = np.array(self.vectorizer_data["idf"])
+            vector = vector * idf
+        
+        return vector
+    
+    def extract_features(self, text: str) -> Dict[str, Any]:
+        """
+        Extrai características do texto para uso na detecção.
+        
+        Args:
+            text: Texto a ser analisado
+            
+        Returns:
+            Características extraídas do texto
+        """
+        # Implementação simplificada - na versão completa, deve replicar extract_features do modelo original
+        return {"text": text}
+    
+    def detect_with_regex(self, text: str) -> Tuple[List[str], List[Tuple[int, int, str]]]:
+        """
+        Detecta credenciais usando padrões regex.
+        
+        Args:
+            text: Texto a ser analisado
+            
+        Returns:
+            Tupla contendo a lista de credenciais encontradas e suas posições
+        """
+        matches = []
+        positions = []
+        
+        if not self.patterns:
+            return matches, positions
+        
+        for pattern_name, pattern in self.patterns.items():
+            for match in pattern.finditer(text):
+                start, end = match.span()
+                credential = text[start:end]
+                matches.append(credential)
+                positions.append((start, end, pattern_name))
+        
+        return matches, positions
+    
+    def detect(self, text: str) -> Dict[str, Any]:
+        """
+        Detecta se o texto contém credenciais.
+        
+        Args:
+            text: Texto a ser analisado
+            
+        Returns:
+            Resultado da detecção com confiança e matches
+        """
+        # Verificar primeiro com regex para casos simples
+        matches, positions = self.detect_with_regex(text)
+        
+        if matches:
+            return {
+                "has_credential": True,
+                "confidence": 1.0,
+                "matches": matches,
+                "match_positions": positions
+            }
+        
+        # Extrair características e vetorizar
+        features = self.extract_features(text)
+        vector = self.vectorize_text(text)
+        
+        # Preparar para inferência
+        input_name = self.session.get_inputs()[0].name
+        vector_reshaped = vector.reshape(1, -1).astype(np.float32)
+        
+        # Fazer a inferência
+        outputs = self.session.run(None, {input_name: vector_reshaped})
+        
+        # Interpretar resultados
+        # O primeiro output geralmente é a classe ou probabilidade
+        probabilities = outputs[0][0]
+        
+        # Classe 1 geralmente é a classe positiva (contém credencial)
+        confidence = probabilities[1] if len(probabilities) > 1 else probabilities[0]
+        has_credential = confidence >= self.confidence_threshold
+        
+        return {
+            "has_credential": has_credential,
+            "confidence": float(confidence),
+            "matches": [text] if has_credential else [],
+            "match_positions": []
+        }
+
+def load_detector(model_directory: str, model_name: str = "credential_detector") -> ONNXCredentialDetector:
+    """
+    Carrega um detector de credenciais ONNX a partir de um diretório.
+    
+    Args:
+        model_directory: Diretório contendo os arquivos do modelo
+        model_name: Nome base do modelo
+        
+    Returns:
+        Detector de credenciais ONNX carregado
+    """
+    model_path = os.path.join(model_directory, f"{model_name}.onnx")
+    config_path = os.path.join(model_directory, f"{model_name}_config.json")
+    vectorizer_path = os.path.join(model_directory, f"{model_name}_vectorizer.json")
+    patterns_path = os.path.join(model_directory, f"{model_name}_patterns.json")
+    
+    return ONNXCredentialDetector(
+        model_path=model_path,
+        config_path=config_path,
+        vectorizer_path=vectorizer_path,
+        patterns_path=patterns_path
+    ) 

--- a/src/utils/onnx_utils.py
+++ b/src/utils/onnx_utils.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Utilitários para converter modelos do projeto para o formato ONNX.
+ONNX (Open Neural Network Exchange) é um formato aberto para modelos de machine learning
+que permite compartilhar modelos entre diferentes frameworks.
+"""
+
+import os
+import pickle
+import logging
+from typing import Any, Dict, Optional, Tuple, List
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from skl2onnx import convert_sklearn
+from skl2onnx.common.data_types import FloatTensorType
+
+logger = logging.getLogger(__name__)
+
+def convert_sklearn_model_to_onnx(
+    model: Any,
+    model_name: str,
+    input_dim: int,
+    output_path: Optional[str] = None
+) -> bytes:
+    """
+    Converte um modelo scikit-learn para o formato ONNX.
+    
+    Args:
+        model: O modelo scikit-learn a ser convertido
+        model_name: Nome do modelo
+        input_dim: Dimensão dos dados de entrada (número de features)
+        output_path: Caminho para salvar o modelo convertido. Se None, apenas retorna os bytes.
+        
+    Returns:
+        Bytes do modelo ONNX.
+    """
+    # Definir o tipo de entrada
+    initial_type = [('input', FloatTensorType([None, input_dim]))]
+    
+    # Converter o modelo para ONNX
+    onnx_model = convert_sklearn(model, model_name, initial_type, target_opset=15)
+    
+    # Verificar o modelo ONNX
+    onnx.checker.check_model(onnx_model)
+    
+    # Serializar para bytes
+    onnx_bytes = onnx_model.SerializeToString()
+    
+    # Salvar o modelo se um caminho foi fornecido
+    if output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            f.write(onnx_bytes)
+        logger.info(f"Modelo ONNX salvo em: {output_path}")
+    
+    return onnx_bytes
+
+def convert_vectorizer_to_onnx(
+    vectorizer: Any, 
+    model_name: str,
+    output_path: Optional[str] = None
+) -> Tuple[Dict, str]:
+    """
+    Como os vectorizers TF-IDF não são diretamente convertíveis para ONNX,
+    extraímos seus parâmetros e vocabulário para reimplementação em outras linguagens.
+    
+    Args:
+        vectorizer: O vectorizer TF-IDF do scikit-learn
+        model_name: Nome do modelo
+        output_path: Caminho para salvar os dados do vectorizer em formato JSON
+        
+    Returns:
+        Dicionário com os parâmetros do vectorizer e caminho para o arquivo salvo
+    """
+    import json
+    
+    # Extrair parâmetros do vectorizer
+    vectorizer_data = {
+        "vocabulary": vectorizer.vocabulary_,
+        "idf": vectorizer.idf_.tolist() if hasattr(vectorizer, 'idf_') else None,
+        "stop_words": list(vectorizer.stop_words_) if hasattr(vectorizer, 'stop_words_') and vectorizer.stop_words_ else None,
+        "ngram_range": vectorizer.ngram_range,
+        "norm": vectorizer.norm,
+        "max_df": vectorizer.max_df,
+        "min_df": vectorizer.min_df,
+        "max_features": vectorizer.max_features,
+        "model_name": model_name
+    }
+    
+    # Salvar como JSON se um caminho foi fornecido
+    if output_path:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(vectorizer_data, f, ensure_ascii=False, indent=2)
+        logger.info(f"Dados do vectorizer salvos em: {output_path}")
+    
+    return vectorizer_data, output_path
+
+def convert_credential_detector_to_onnx(
+    model_path: str,
+    output_dir: str,
+    model_name: str = "credential_detector"
+) -> Dict[str, str]:
+    """
+    Converte o modelo CredentialDetector para formato ONNX.
+    
+    Args:
+        model_path: Caminho para o arquivo .pkl do modelo treinado
+        output_dir: Diretório onde os arquivos convertidos serão salvos
+        model_name: Nome base para os arquivos gerados
+    
+    Returns:
+        Dicionário com os caminhos para os arquivos gerados
+    """
+    # Criar o diretório de saída se não existir
+    os.makedirs(output_dir, exist_ok=True)
+    
+    # Carregar o modelo
+    with open(model_path, "rb") as f:
+        model_data = pickle.load(f)
+    
+    classifier = model_data["classifier"]
+    vectorizer = model_data["vectorizer"]
+    feature_extractor = model_data.get("feature_extractor")
+    config = model_data.get("config", {})
+    
+    # Caminhos dos arquivos de saída
+    onnx_model_path = os.path.join(output_dir, f"{model_name}.onnx")
+    vectorizer_path = os.path.join(output_dir, f"{model_name}_vectorizer.json")
+    config_path = os.path.join(output_dir, f"{model_name}_config.json")
+    
+    # Converter o classificador para ONNX
+    # Precisamos determinar a dimensão de entrada
+    input_dim = len(vectorizer.vocabulary_)
+    onnx_bytes = convert_sklearn_model_to_onnx(
+        classifier, 
+        model_name, 
+        input_dim,
+        onnx_model_path
+    )
+    
+    # Converter o vectorizer (extrair parâmetros)
+    vectorizer_data, _ = convert_vectorizer_to_onnx(
+        vectorizer,
+        f"{model_name}_vectorizer",
+        vectorizer_path
+    )
+    
+    # Salvar a configuração
+    import json
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "model_name": model_name,
+            "onnx_version": onnx.__version__,
+            "input_dim": input_dim,
+            "config": config,
+            "feature_names": list(vectorizer.get_feature_names_out()) if hasattr(vectorizer, 'get_feature_names_out') else [],
+            "patterns": model_data.get("patterns", {}),
+            "confidence_threshold": model_data.get("confidence_threshold", 0.7)
+        }, f, ensure_ascii=False, indent=2)
+    
+    logger.info(f"Conversão ONNX concluída. Arquivos salvos em: {output_dir}")
+    
+    return {
+        "onnx_model": onnx_model_path,
+        "vectorizer": vectorizer_path,
+        "config": config_path
+    }
+
+def test_onnx_inference(
+    onnx_model_path: str,
+    input_data: np.ndarray
+) -> np.ndarray:
+    """
+    Testa a inferência usando o modelo ONNX.
+    
+    Args:
+        onnx_model_path: Caminho para o modelo ONNX
+        input_data: Array NumPy com os dados de entrada
+        
+    Returns:
+        Resultado da inferência
+    """
+    # Carregar o modelo ONNX
+    session = ort.InferenceSession(onnx_model_path)
+    
+    # Obter o nome da entrada
+    input_name = session.get_inputs()[0].name
+    
+    # Fazer a inferência
+    result = session.run(None, {input_name: input_data.astype(np.float32)})
+    
+    return result 

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Testes para a exportação de modelos para ONNX.
+"""
+
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+import pickle
+from unittest import mock
+
+# Garantir que os módulos do projeto estão no path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import numpy as np
+
+try:
+    import onnx
+    import onnxruntime as ort
+    has_onnx = True
+except ImportError:
+    has_onnx = False
+    
+# Skip decorator para pular testes quando ONNX não está disponível
+skip_if_no_onnx = unittest.skipIf(not has_onnx, "ONNX não está disponível")
+
+class TestONNXExport(unittest.TestCase):
+    """Testes para exportação ONNX."""
+    
+    def setUp(self):
+        """Configuração para os testes."""
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.feature_extraction.text import TfidfVectorizer
+        
+        # Criar um diretório temporário para os testes
+        self.test_dir = tempfile.mkdtemp()
+        self.model_path = os.path.join(self.test_dir, "test_model.pkl")
+        self.output_dir = os.path.join(self.test_dir, "onnx")
+        os.makedirs(self.output_dir, exist_ok=True)
+        
+        # Criar um modelo simples para teste
+        vectorizer = TfidfVectorizer(max_features=10)
+        X = ["teste1", "teste2", "credencial1", "credencial2"]
+        vectorizer.fit(X)
+        
+        X_vec = vectorizer.transform(X)
+        y = [0, 0, 1, 1]  # 0 = não credencial, 1 = credencial
+        
+        # Treinar um classificador
+        clf = RandomForestClassifier(n_estimators=10, random_state=42)
+        clf.fit(X_vec, y)
+        
+        # Salvar o modelo
+        model_data = {
+            "classifier": clf,
+            "vectorizer": vectorizer,
+            "feature_extractor": lambda x: {"text": x},
+            "config": {"test": True},
+            "confidence_threshold": 0.7,
+            "patterns": {"api_key": r"API_KEY=\w+"}
+        }
+        
+        with open(self.model_path, "wb") as f:
+            pickle.dump(model_data, f)
+    
+    def tearDown(self):
+        """Limpeza após os testes."""
+        # Remover diretório temporário
+        shutil.rmtree(self.test_dir)
+    
+    @skip_if_no_onnx
+    def test_convert_sklearn_model_to_onnx(self):
+        """Testa a conversão de um modelo scikit-learn para ONNX."""
+        from src.utils.onnx_utils import convert_sklearn_model_to_onnx
+        
+        # Carregar o modelo
+        with open(self.model_path, "rb") as f:
+            model_data = pickle.load(f)
+        
+        classifier = model_data["classifier"]
+        
+        # Converter o modelo
+        onnx_path = os.path.join(self.output_dir, "test_model.onnx")
+        onnx_bytes = convert_sklearn_model_to_onnx(
+            model=classifier,
+            model_name="test_model",
+            input_dim=10,  # Dimensão do vectorizer
+            output_path=onnx_path
+        )
+        
+        # Verificar se o arquivo foi criado
+        self.assertTrue(os.path.exists(onnx_path))
+        
+        # Verificar se o modelo é válido
+        onnx_model = onnx.load(onnx_path)
+        self.assertIsNotNone(onnx_model)
+    
+    @skip_if_no_onnx
+    def test_convert_vectorizer_to_onnx(self):
+        """Testa a exportação dos dados do vectorizer."""
+        from src.utils.onnx_utils import convert_vectorizer_to_onnx
+        
+        # Carregar o modelo
+        with open(self.model_path, "rb") as f:
+            model_data = pickle.load(f)
+        
+        vectorizer = model_data["vectorizer"]
+        
+        # Converter o vectorizer
+        vectorizer_path = os.path.join(self.output_dir, "test_vectorizer.json")
+        vectorizer_data, output_path = convert_vectorizer_to_onnx(
+            vectorizer=vectorizer,
+            model_name="test_vectorizer",
+            output_path=vectorizer_path
+        )
+        
+        # Verificar se o arquivo foi criado
+        self.assertTrue(os.path.exists(vectorizer_path))
+        
+        # Verificar se os dados são válidos
+        self.assertIn("vocabulary", vectorizer_data)
+        self.assertIn("idf", vectorizer_data)
+    
+    @skip_if_no_onnx
+    def test_convert_credential_detector_to_onnx(self):
+        """Testa a conversão completa do detector de credenciais para ONNX."""
+        from src.utils.onnx_utils import convert_credential_detector_to_onnx
+        
+        # Converter o modelo
+        export_paths = convert_credential_detector_to_onnx(
+            model_path=self.model_path,
+            output_dir=self.output_dir,
+            model_name="test_detector"
+        )
+        
+        # Verificar se os arquivos foram criados
+        self.assertTrue(os.path.exists(export_paths["onnx_model"]))
+        self.assertTrue(os.path.exists(export_paths["vectorizer"]))
+        self.assertTrue(os.path.exists(export_paths["config"]))
+    
+    @skip_if_no_onnx
+    def test_export_onnx_script(self):
+        """Testa o script de exportação completo."""
+        # Importar apenas se ONNX estiver disponível
+        from src.export.export_onnx import export_model
+        
+        # Exportar o modelo
+        test_examples = ["teste", "API_KEY=12345"]
+        export_results = export_model(
+            model_path=self.model_path,
+            output_dir=self.output_dir,
+            model_name="test_export",
+            test_examples=test_examples
+        )
+        
+        # Verificar se os arquivos foram criados
+        self.assertTrue(os.path.exists(export_results["onnx_model"]))
+        self.assertTrue(os.path.exists(export_results["vectorizer"]))
+        self.assertTrue(os.path.exists(export_results["config"]))
+        self.assertTrue(os.path.exists(export_results["patterns"]))
+        
+        # Verificar se os exemplos de implementação foram gerados
+        php_example = os.path.join(self.output_dir, "test_export_php_example.php")
+        js_example = os.path.join(self.output_dir, "test_export_js_example.js")
+        self.assertTrue(os.path.exists(php_example))
+        self.assertTrue(os.path.exists(js_example))
+    
+    @skip_if_no_onnx
+    def test_onnx_loader(self):
+        """Testa o carregador de modelos ONNX."""
+        # Primeiro exportar o modelo
+        from src.export.export_onnx import export_model
+        export_model(
+            model_path=self.model_path,
+            output_dir=self.output_dir,
+            model_name="test_loader"
+        )
+        
+        # Depois carregar o modelo exportado
+        from src.utils.onnx_loader import load_detector
+        
+        detector = load_detector(
+            model_directory=self.output_dir,
+            model_name="test_loader"
+        )
+        
+        # Testar detecção
+        result = detector.detect("API_KEY=12345")
+        self.assertTrue(result["has_credential"])
+        
+        result = detector.detect("texto normal sem credenciais")
+        self.assertFalse(result["has_credential"])
+
+if __name__ == "__main__":
+    unittest.main() 


### PR DESCRIPTION
## Descrição

Este PR adiciona suporte para exportação de modelos para o formato ONNX (Open Neural Network Exchange), permitindo que o detector de credenciais seja utilizado em outras linguagens como PHP e JavaScript.

### Principais alterações:

1. **Adição de dependências ONNX**:
   - Adicionadas bibliotecas necessárias no `requirements.txt`
   - Suporte para onnx, onnxruntime e skl2onnx

2. **Módulo de utilitários ONNX**: 
   - Criado `src/utils/onnx_utils.py` para conversão de modelos scikit-learn para ONNX
   - Funções para converter classificadores e vectorizers

3. **Módulo de carregamento ONNX**:
   - Implementado `src/utils/onnx_loader.py` para carregamento e uso de modelos ONNX
   - Classe `ONNXCredentialDetector` para detecção com modelos ONNX

4. **Script de exportação**:
   - Novo módulo `src/export/export_onnx.py` para exportação de modelos
   - Gera exemplos de implementação em PHP e JavaScript

5. **Script de treinamento atualizado**:
   - O script `src/training/train_model.py` agora exporta automaticamente para ONNX após o treinamento
   - Mantém compatibilidade com treinamentos existentes

6. **Comandos Makefile**:
   - Adicionados comandos `export-onnx` e `export-onnx-rocm` no Makefile

7. **Testes unitários**:
   - Adicionados testes para verificar a exportação ONNX
   - Implementado `tests/test_onnx_export.py`

8. **Exemplo de uso**:
   - Criado `examples/use_onnx_detector.py` para demonstrar o uso do detector ONNX

9. **Documentação README**:
   - Atualizado com informações sobre ONNX e exemplos de uso

### Vantagens:

- Compatibilidade com múltiplas linguagens de programação
- Melhor performance de inferência
- Maior portabilidade

### Como testar:

1. Instalar as dependências: `pip install -r requirements.txt`
2. Treinar o modelo: `make train`
3. Verificar arquivos gerados em `models/onnx/`
4. Testar o detector ONNX: `python examples/use_onnx_detector.py`

Testes unitários podem ser executados com:
```
python -m pytest tests/test_onnx_export.py -v
```